### PR TITLE
fix warning/Value for constant 'NodeName' was modified

### DIFF
--- a/templates/zones.conf.j2
+++ b/templates/zones.conf.j2
@@ -1,7 +1,3 @@
-{% if icinga2_nodename %}
-const NodeName = "{{ icinga2_nodename }}"
-{% endif %}
-
 {% set i2o_type = "Endpoint" %}
 {% for i2o_name1 in icinga2_endpoints %}
 {% include './templates/_object_endpoints.conf.j2' %}


### PR DESCRIPTION
NodeName is already defined in constants.conf and should only be defined
once.